### PR TITLE
Added hotkey support for opening file dialog on ImportCharacter screen and Picklist for Name

### DIFF
--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/.import/Gandalf_data.csv-5a92aae8e99e27e1495221194c829f0b.md5
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/.import/Gandalf_data.csv-5a92aae8e99e27e1495221194c829f0b.md5
@@ -1,0 +1,1 @@
+source_md5="913de2faf6921aa7853aef500debf800"

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/Character_Add.gd
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/Character_Add.gd
@@ -22,6 +22,34 @@ func _ready() -> void:
 	$Title/But_SaveChar.grab_focus()
 	_populate_output_character_format()
 
+# FUNCTION: get_character_names_from_csv_folder
+# --------------------------------------------
+# Scans the res://_userFiles/characterFiles/ directory for all character CSV files
+# matching the pattern *_data.csv. Extracts and returns the character names (from filenames)
+# to populate the character name dropdown (OptionButton) in the UI.
+#
+# RETURNS:
+#   Array of character names as strings, e.g. ["Bilbo Baggins", "Gandalf"]
+func get_character_names_from_csv_folder() -> Array:
+	var names = []
+	var dir := Directory.new()
+
+	if dir.open("res://_userFiles/characterFiles/") != OK:
+		print("❌ Failed to open characterFiles directory.")
+		return names
+
+	dir.list_dir_begin()
+	while true:
+		var file_name = dir.get_next()
+		if file_name == "":
+			break
+		if !dir.current_is_dir() and file_name.ends_with("_data.csv"):
+			var name_only = file_name.replace("_data.csv", "")
+			names.append(name_only)
+	dir.list_dir_end()
+
+	return names
+	
 #FUNCTION populate preset character format
 #Params: file we have opened and are reading
 #Returns: Nothing; all work done in function
@@ -31,17 +59,46 @@ func _ready() -> void:
 #TODO: Next step  here is run the GSP converted to also update the percentile/singleton
 func _populate_output_character_format():
 	var i = 0
+	# Original code - COMMENTED OUT:
 	#make a new textbox for each header piece
-	var set_labels = ["NAME","PROFESSION","QUOTE"]
+#	var set_labels = ["NAME","PROFESSION","QUOTE"]
+#	for set in set_labels:
+	#	var setLine = Label.new()
+	#	setLine.text = set
+	#	$Title/ScrollContainer/VBoxContainer.add_child(setLine)
+	#	cust_cap_count= cust_cap_count+1
+	#	var setBox = LineEdit.new()
+	#	$Title/ScrollContainer/VBoxContainer.add_child(setBox)
+	#	cust_cap_count = cust_cap_count+1
+
+# Updated code to replace NAME textbox with a dropdown (OptionButton)
+###############
+	var set_labels = ["NAME", "PROFESSION", "QUOTE"]
 	for set in set_labels:
+	# Create label for each field
 		var setLine = Label.new()
 		setLine.text = set
 		$Title/ScrollContainer/VBoxContainer.add_child(setLine)
-		cust_cap_count= cust_cap_count+1
-		var setBox = LineEdit.new()
-		$Title/ScrollContainer/VBoxContainer.add_child(setBox)
-		cust_cap_count = cust_cap_count+1
+		cust_cap_count += 1
 
+		if set == "NAME":
+			# Replace LineEdit with OptionButton (dropdown) for NAME
+			var name_dropdown = OptionButton.new()
+			name_dropdown.name = "NameOption"  # Assign a name so we can access it later
+			# Add options from predefined character presets
+			for char_name in get_character_names_from_csv_folder():
+				name_dropdown.add_item(char_name)
+			# Connect dropdown selection signal
+			name_dropdown.connect("item_selected", self, "_on_name_selected")
+			# Add dropdown to the form
+			$Title/ScrollContainer/VBoxContainer.add_child(name_dropdown)
+			cust_cap_count += 1
+		else:
+			# Keeps LineEdit for PROFESSION and QUOTE
+			var setBox = LineEdit.new()
+			$Title/ScrollContainer/VBoxContainer.add_child(setBox)
+			cust_cap_count += 1
+###############
 
 	#DKM TEMP (12/22/24): Putting in direct access to the percentile system, as 
 	#	the Capabilities system is tested. These values should be set on the GSP as

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/ImportCharacter.gd
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/ImportCharacter.gd
@@ -31,6 +31,10 @@ func _ready() -> void:
 func _on_Button_pressed():
 	$FileDialog.popup()
 
+# Opens the file dialog popup when the custom hotkey (e.g., Ctrl + O) is pressed
+func _unhandled_input(event):
+	if Input.is_action_pressed("open_file_hotkey"):
+		$FileDialog.popup()
 
 #FUNCTION populate preset character format
 #Params: file we have opened and are reading

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/_userFiles/characterFiles/Gandalf_data.csv
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/_userFiles/characterFiles/Gandalf_data.csv
@@ -1,0 +1,2 @@
+Name,Profession,Quote,AG,APP,CO,QU,MD,ST,CH,EM,IN,ME,MX,PR,RE,SD,Health,Defense,Vision,The One Ring,Sting,
+Gandalf,Wizard,"A wizard is never late, nor is he early.",80,70,65,85,90,60,75,85,95,80,90,70,70,65,100,80,99,50,

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/_userFiles/characterFiles/Gandalf_data.csv.import
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/_userFiles/characterFiles/Gandalf_data.csv.import
@@ -1,0 +1,13 @@
+[remap]
+
+importer="csv_translation"
+type="Translation"
+valid=false
+
+[deps]
+
+source_file="res://_userFiles/characterFiles/Gandalf_data.csv"
+[params]
+
+compress=true
+delimiter=0

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/project.godot
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/project.godot
@@ -110,6 +110,14 @@ DiceRoller="*res://globalScripts/DiceRoller.gd"
 GlobalSaveInstance="*res://globalScripts/globalSaveInstance.gd"
 GameCurrent="*res://globalScripts/gameCurrent.gd"
 
+[input]
+
+open_file_hotkey={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":true,"command":true,"pressed":false,"scancode":0,"physical_scancode":79,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
 [physics]
 
 common/enable_pause_aware_picking=true


### PR DESCRIPTION
This pull request adds support for a keyboard hotkey (open_file_hotkey) to open the character import file dialog. It improves accessibility for keyboard-only and BCI users.

Changes
Added open_file_hotkey in Input Map
Implemented _unhandled_input() in ImportCharacter.gd
Opens $FileDialog when the hotkey is pressed

Tested
Verified that pressing the hotkey triggers the file dialog without needing a mouse click
Tested in both default and custom themes

